### PR TITLE
Fix phf::Map::get call

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ fn to_fixed<'a>(p: String, a: &'a Args) -> String {
     // 替换拼音中的带声调字符
     let py = re_phonetic_symbol.replace_all(&p, |caps: &Captures| {
         let cap = caps.at(0).unwrap();
-        let symbol = match PHONETIC_SYMBOL_MAP.get(&cap) {
+        let symbol = match PHONETIC_SYMBOL_MAP.get(cap) {
             Some(&v) => v,
             None => "",
         };


### PR DESCRIPTION
Fix phf::Map::get call

This fixes a regression that caused the crate to stop compiling on
current rust nightly and beta versions.

`cap` is already a `&str`, so passing just `cap` instead of `&cap` is
fine.
