### PR TITLE
Use env::var_os intead of env! in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,12 @@
 extern crate phf_codegen;
 
+use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
 fn main() {
-    let path = Path::new(env!("OUT_DIR")).join("codegen.rs");
+    let path = Path::new(&env::var_os("OUT_DIR").unwrap()).join("codegen.rs");
     let mut file = BufWriter::new(File::create(&path).unwrap());
 
     let mut builder = phf_codegen::Map::new();


### PR DESCRIPTION
The env! method pulls the variable at *compile time* as opposed to runtime. This
can cause breakage in scenarios with cross compilation, for example. Currently
there's also a pending change to Cargo on the beta release of Rust which breaks
the usage of env! (rust-lang/cargo#3368).

We may roll that change back, but I figured it'd be good to head off future
breakage anyway!