### PR TITLE
Improve travis ci codecov performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
 after_success:
   - |
     if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-      cargo coveralls
+      cargo coveralls --all-features --release --exclude-pattern 'tests/*,src/bin/*'
     fi
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: rust
 sudo: required
 dist: trusty
 
-cache: cargo
+cache:
+  directories:
+    - $HOME/.rustup/
+    - $HOME/.cargo/
 
 addons:
   apt:
@@ -28,16 +31,16 @@ script:
   - cargo bench
   - |
     if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-      # install cargo-tarpaulin here to that dependency crates can be cached properly
-      cargo install cargo-tarpaulin
+      # install cargo-travis here to that dependency crates can be cached properly
+      cargo install cargo-update || echo "cargo-update already installed"
+      cargo install cargo-travis || echo "cargo-travis already installed"
+      cargo install-update -a # update outdated cached binaries
     fi
 
 after_success:
   - |
     if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-      RUSTFLAGS="--cfg procmacro2_semver_exempt"
-      cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID \
-        --exclude-files 'tests/*' --exclude-files 'src/bin/*'
+      cargo coveralls
     fi
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,13 @@ cache:
 addons:
   apt:
     packages:
-      - libssl-dev
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - binutils-dev
+      - cmake # also required for cargo-update
+    sources:
+      - kalakris-cmake
 
 rust:
   - 1.29.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,21 +20,25 @@ rust:
   - nightly
 
 script:
+  - cargo clean
+  - cargo build --release
+  - cargo test --release
+  - cargo doc -p pinyin --no-deps
+  - cargo run --example main
+  - cargo bench
   - |
-      cargo clean &&
-      cargo build --release &&
-      cargo test --release &&
-      cargo doc -p pinyin --no-deps &&
-      cargo run --example main &&
-      cargo bench
+    if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+      # install cargo-tarpaulin here to that dependency crates can be cached properly
+      cargo install cargo-tarpaulin
+    fi
 
 after_success:
   - |
-      if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-        RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
-        cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID \
-          --exclude-files 'tests/*' --exclude-files 'src/bin/*'
-      fi
+    if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+      RUSTFLAGS="--cfg procmacro2_semver_exempt"
+      cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID \
+        --exclude-files 'tests/*' --exclude-files 'src/bin/*'
+    fi
 
 matrix:
   allow_failures:


### PR DESCRIPTION
It may take 30min for the first time to install cargo-update and cargo-travis but will take <2 min afterwards, while now it takes >10min to run every build with tarpaulin