### PR TITLE
精简.travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,5 @@
 language: rust
-sudo: required
 dist: trusty
-
-
-addons:
-  apt:
-    packages:
-      - libcurl4-openssl-dev
-      - libelf-dev
-      - libdw-dev
-      - binutils-dev
-      - cmake # also required for cargo-update
-    sources:
-      - kalakris-cmake
 
 rust:
   - stable
@@ -30,7 +17,7 @@ after_success:
         curl -sL https://github.com/xd009642/tarpaulin/releases/download/0.8.3/cargo-tarpaulin-0.8.3-travis.tar.gz | \
           tar xvz -C $HOME/.cargo/bin
         cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID \
-          --exclude-files 'tests/*' --exclude-files 'src/bin/*'
+          --exclude-files 'tests/*'
       fi
 
 matrix:


### PR DESCRIPTION
去掉没有必要的apt安装和root权限，CI的运行时间可以短许多。