### PR TITLE
删除rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-error_on_line_overflow = false


### PR DESCRIPTION
这个文件看起来没什么用了，删掉也没有东西会报错的样子。