### PR TITLE
拆分CI脚本

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,50 +1,20 @@
 dist: xenial
 language: rust
-cache: cargo
+
+cache:
+  # 不缓存target，因为没有依赖
+  directories:
+    - $HOME/.cargo
+
+rust:
+  - stable
+  - beta
+  - nightly
+
+before_script: ci/install_extra.sh
+script: ci/script.sh
+after_success: ci/coveralls.sh
 
 matrix:
   allow_failures:
     - rust: nightly
-  include:
-    - name: "GNU/Linux Rust Stable"
-      rust: stable
-      before_script:
-        - rustup component add rustfmt clippy
-        - rustfmt --version
-        - cargo clippy --version
-      script:
-        - cargo build
-        - cargo test
-        - cargo test --no-default-features --features=plain
-        - cargo test --no-default-features --features=with_tone
-        - cargo test --no-default-features --features=with_tone_num
-        - cargo test --no-default-features --features=with_tone_num_end
-        - cargo test --no-default-features --features=plain,heteronym
-        - cargo test --no-default-features --features=with_tone,heteronym
-        - cargo test --no-default-features --features=with_tone_num,heteronym
-        - cargo test --no-default-features --features=with_tone_num_end,heteronym
-        - cargo fmt --all -- --check
-      after_success:
-        - |
-            if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-              curl -sL https://github.com/xd009642/tarpaulin/releases/download/0.8.3/cargo-tarpaulin-0.8.3-travis.tar.gz | \
-                tar xvz -C $HOME/.cargo/bin
-              cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID \
-                --exclude-files 'tests/*' --exclude-files 'coverage-check/*'
-            fi
-
-    - name: "GNU/Linux Rust Nightly"
-      rust: nightly
-      script:
-        - cargo build
-        - cargo test
-        - cargo test --no-default-features --features=plain
-        - cargo test --no-default-features --features=with_tone
-        - cargo test --no-default-features --features=with_tone_num
-        - cargo test --no-default-features --features=with_tone_num_end
-        - cargo test --no-default-features --features=plain,heteronym
-        - cargo test --no-default-features --features=with_tone,heteronym
-        - cargo test --no-default-features --features=with_tone_num,heteronym
-        - cargo test --no-default-features --features=with_tone_num_end,heteronym
-        - cargo doc
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,27 +1,15 @@
-image:
-  - Visual Studio 2017
-environment:
-  matrix:
-    - RUST_TOOL_CHAIN: stable
-  #- RUST_TOOL_CHAIN: nightly
 install:
   - git submodule update --init --recursive
-  - ps: iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
-  - scoop install rustup
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc
   - refreshenv
-  - rustup default %RUST_TOOL_CHAIN%
-  - rustup component add rustfmt
   - rustc -V
   - cargo -V
-build_script:
-  - cargo build
+  - bash ci/install_extra.sh
+
+build: off
 test_script:
-  - cargo test
-  - cargo doc
-  - cargo bench
-  - cargo fmt --all -- --check
-#branches:
-#  only:
-#    - master
+  - bash ci/script.sh
+
 pull_requests:
   do_not_increment_build_number: true

--- a/ci/coveralls.sh
+++ b/ci/coveralls.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+  curl -sL https://github.com/xd009642/tarpaulin/releases/download/0.8.3/cargo-tarpaulin-0.8.3-travis.tar.gz | \
+    tar xvz -C $HOME/.cargo/bin
+  cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID \
+    --exclude-files 'tests/*' --exclude-files 'coverage-check/*'
+fi

--- a/ci/install_extra.sh
+++ b/ci/install_extra.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -ex
+
+rustup component add rustfmt clippy
+rustfmt --version
+cargo clippy --version

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -ex
+
+cargo fmt --all -- --check
+cargo clippy
+
+cargo build
+cargo test
+
+cargo test --no-default-features --features=plain
+cargo test --no-default-features --features=with_tone
+cargo test --no-default-features --features=with_tone_num
+cargo test --no-default-features --features=with_tone_num_end
+
+cargo test --no-default-features --features=plain,heteronym
+cargo test --no-default-features --features=with_tone,heteronym
+cargo test --no-default-features --features=with_tone_num,heteronym
+cargo test --no-default-features --features=with_tone_num_end,heteronym


### PR DESCRIPTION
做了几件事：
* 将测试脚本放入独立的bash文件，方便本地执行
* 将Travis CI的缓存修改为只缓存 `.cargo`，应当可以加速一些index update，但避免缓存无用的编译结果
* 恢复nightly里的clippy检查
* 在AppVeyor上改用curl安装rustup，避免安装两套工具链（gnu然后msvc）
* 在AppVeyor上也使用同样的测试脚本