### PR TITLE
添加phrase dict的支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 
 # Created by https://www.gitignore.io/api/rust,code,intellij+all
 # Edit at https://www.gitignore.io/?templates=rust,code,intellij+all

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "pinyin-data"]
 	path = pinyin-data
 	url = https://github.com/mozillazg/pinyin-data.git
+[submodule "phrase-pinyin-data"]
+	path = phrase-pinyin-data
+	url = https://github.com/mozillazg/phrase-pinyin-data

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ include = [
 ]
 edition = "2018"
 
+[dependencies]
+lazy_static = "1.4.0"
+
 [workspace]
 members = ["coverage-check"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ edition = "2018"
 
 [dependencies]
 lazy_static = "1.4.0"
+seq-macro = "0.3.2"
 
 [workspace]
 members = ["coverage-check"]

--- a/build.rs
+++ b/build.rs
@@ -384,20 +384,24 @@ fn generate_phrase_table(
 ) -> io::Result<()> {
     // 输出字符表
     let mut output = create_out_file("phrase_table.rs")?;
-    writeln!(output, "&[")?;
+    writeln!(output, "{{")?;
+    writeln!(output, "let mut m = HashMap::new();")?;
     for (phrase, pinyins) in data {
-        let pinyin_indices: Vec<String> = pinyins.iter().map(|pinyin| {
-            let pinyin_indices_list = pinyin.split(' ').map(
+        let mut syllables = 0;
+        let mut pinyin_indices: Vec<String> = pinyins.iter().map(|pinyin| {
+            pinyin.split(' ').map(
                 |syllable| {
-                    // dbg!(syllable);
+                    syllables += 1;
                     pinyin_index.get(syllable).unwrap().to_string()
                 }
-            ).collect::<Vec<String>>().join(", ");
-            format!("&[{}]", pinyin_indices_list)
+            ).collect::<Vec<String>>().join(", ")
         }).collect();
-        writeln!(output, "    (\"{}\", &[{}]),", phrase, pinyin_indices.join(", "))?;
+        let pad_len = 19 - syllables;
+        pinyin_indices.extend(std::iter::repeat("0".to_string()).take(pad_len));
+        writeln!(output, "    m.insert(\"{}\", &[{}]);", phrase, pinyin_indices.join(", "))?;
     }
-    writeln!(output, "]")?;
+    writeln!(output, "m")?;
+    writeln!(output, "}}")?;
     Ok(())
 }
 

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,11 @@ const RAW_DATA: &str = include_str!(concat!(
     "/pinyin-data/pinyin.txt"
 ));
 
+const RAW_PHRASE_DATA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/phrase-pinyin-data/pinyin.txt"
+));
+
 #[cfg(any(
     feature = "plain",
     feature = "with_tone_num",
@@ -81,6 +86,7 @@ const TONE_NUMS: &[char] = &['0', '1', '2', '3', '4'];
 
 type Style = (&'static str, fn(&str) -> Cow<'_, str>);
 type InputData = Vec<(u32, Vec<&'static str>)>;
+type PhraseInputData = HashMap<&'static str, Vec<&'static str>>;
 type PinyinDataIndex = HashMap<&'static str, usize>;
 type HeteronymDataIndex = HashMap<u32, usize>;
 
@@ -89,6 +95,10 @@ fn main() -> io::Result<()> {
     let pinyin_index = generate_pinyin_data(&data)?;
     let heteronym_index = generate_heteronym_table(&data, &pinyin_index)?;
     generate_char_table(&data, &pinyin_index, &heteronym_index)?;
+    
+    let phrase_data = build_phrase_data();
+    generate_phrase_table(&phrase_data, &pinyin_index)?;
+
     // 输出这行以保证改动项目的其他文件不会触发编译脚本重新执行
     println!("cargo:rerun-if-changed=build.rs");
     Ok(())
@@ -141,6 +151,47 @@ fn build_data() -> InputData {
         })
         .collect::<Vec<_>>();
     input_data.sort_by_key(|(code, _)| *code);
+    input_data
+}
+
+fn build_phrase_data() -> PhraseInputData {
+    let mut input_data: HashMap<&str, Vec<&str>> = HashMap::new();
+    RAW_PHRASE_DATA
+        .lines()
+        .enumerate()
+        // 移除注释和空格
+        .map(|(i, mut line)| {
+            if let Some(hash_pos) = line.find('#') {
+                line = &line[..hash_pos];
+            }
+            (i, line.trim())
+        })
+        // 移除空行
+        .filter(|(_, line)| !line.is_empty())
+        .for_each(|(i, line)| {
+            // Split the line by colon
+            let colon_pos = match line.find(':') {
+                Some(pos) => pos,
+                None => unreachable!("no colon found in line {}", i),
+            };
+            let phrase = line[..colon_pos].trim();
+            let pinyin = line[colon_pos + 1..].trim();
+
+            // 确保输入数据的字符全部在我们预料之中。
+            // 同时也可以提前知道一些被遗弃的码位，如: U+E7C8 和 U+E7C7
+            for syllable in pinyin.split(' ') {
+                for ch in syllable.chars() {
+                    let is_known = LETTER_TABLE.contains(&ch);
+                    assert!(
+                        is_known,
+                        "unknown character {:?} at line {}: {}",
+                        ch, i, line,
+                    );
+                }
+            }
+
+            input_data.entry(phrase).or_default().push(pinyin);
+        });
     input_data
 }
 
@@ -322,6 +373,29 @@ fn generate_char_table(
             write!(output, "], ")?;
         }
         writeln!(output, "}},")?;
+    }
+    writeln!(output, "]")?;
+    Ok(())
+}
+
+fn generate_phrase_table(
+    data: &PhraseInputData,
+    pinyin_index: &PinyinDataIndex,
+) -> io::Result<()> {
+    // 输出字符表
+    let mut output = create_out_file("phrase_table.rs")?;
+    writeln!(output, "&[")?;
+    for (phrase, pinyins) in data {
+        let pinyin_indices: Vec<String> = pinyins.iter().map(|pinyin| {
+            let pinyin_indices_list = pinyin.split(' ').map(
+                |syllable| {
+                    // dbg!(syllable);
+                    pinyin_index.get(syllable).unwrap().to_string()
+                }
+            ).collect::<Vec<String>>().join(", ");
+            format!("&[{}]", pinyin_indices_list)
+        }).collect();
+        writeln!(output, "    (\"{}\", &[{}]),", phrase, pinyin_indices.join(", "))?;
     }
     writeln!(output, "]")?;
     Ok(())

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::unreadable_literal)]
 
 use crate::{CharBlock, PinyinData};
+use std::collections::HashMap;
 
 pub(crate) static PINYIN_DATA: &[PinyinData] =
     include!(concat!(env!("OUT_DIR"), "/pinyin_data.rs"));
@@ -10,3 +11,6 @@ pub(crate) static HETERONYM_TABLE: &[&[u16]] =
     include!(concat!(env!("OUT_DIR"), "/heteronym_table.rs"));
 
 pub(crate) static CHAR_BLOCKS: &[CharBlock] = include!(concat!(env!("OUT_DIR"), "/char_blocks.rs"));
+
+pub(crate) static PHRASE_TABLE: &[(&'static str, &[&[usize]])] =
+    include!(concat!(env!("OUT_DIR"), "/phrase_table.rs"));

--- a/src/data.rs
+++ b/src/data.rs
@@ -2,6 +2,7 @@
 
 use crate::{CharBlock, PinyinData};
 use lazy_static::lazy_static;
+use seq_macro::seq;
 use std::collections::HashMap;
 
 pub(crate) static PINYIN_DATA: &[PinyinData] =
@@ -13,44 +14,9 @@ pub(crate) static HETERONYM_TABLE: &[&[u16]] =
 
 pub(crate) static CHAR_BLOCKS: &[CharBlock] = include!(concat!(env!("OUT_DIR"), "/char_blocks.rs"));
 
-pub(crate) static PHRASE_TABLE_HETERONYMS: &[(&'static str, &[&[u16]])] =
-    include!(concat!(env!("OUT_DIR"), "/phrase_table_heteronyms.rs"));
-
-lazy_static! {
-    pub(crate) static ref PHRASE_TABLE_2: HashMap<&'static str, &'static [u16; 2]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_2.rs")));
-    pub(crate) static ref PHRASE_TABLE_3: HashMap<&'static str, &'static [u16; 3]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_3.rs")));
-    pub(crate) static ref PHRASE_TABLE_4: HashMap<&'static str, &'static [u16; 4]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_4.rs")));
-    pub(crate) static ref PHRASE_TABLE_5: HashMap<&'static str, &'static [u16; 5]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_5.rs")));
-    pub(crate) static ref PHRASE_TABLE_6: HashMap<&'static str, &'static [u16; 6]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_6.rs")));
-    pub(crate) static ref PHRASE_TABLE_7: HashMap<&'static str, &'static [u16; 7]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_7.rs")));
-    pub(crate) static ref PHRASE_TABLE_8: HashMap<&'static str, &'static [u16; 8]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_8.rs")));
-    pub(crate) static ref PHRASE_TABLE_9: HashMap<&'static str, &'static [u16; 9]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_9.rs")));
-    pub(crate) static ref PHRASE_TABLE_10: HashMap<&'static str, &'static [u16; 10]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_10.rs")));
-    pub(crate) static ref PHRASE_TABLE_11: HashMap<&'static str, &'static [u16; 11]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_11.rs")));
-    pub(crate) static ref PHRASE_TABLE_12: HashMap<&'static str, &'static [u16; 12]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_12.rs")));
-    pub(crate) static ref PHRASE_TABLE_13: HashMap<&'static str, &'static [u16; 13]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_13.rs")));
-    pub(crate) static ref PHRASE_TABLE_14: HashMap<&'static str, &'static [u16; 14]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_14.rs")));
-    pub(crate) static ref PHRASE_TABLE_15: HashMap<&'static str, &'static [u16; 15]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_15.rs")));
-    pub(crate) static ref PHRASE_TABLE_16: HashMap<&'static str, &'static [u16; 16]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_16.rs")));
-    pub(crate) static ref PHRASE_TABLE_17: HashMap<&'static str, &'static [u16; 17]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_17.rs")));
-    pub(crate) static ref PHRASE_TABLE_18: HashMap<&'static str, &'static [u16; 18]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_18.rs")));
-    pub(crate) static ref PHRASE_TABLE_19: HashMap<&'static str, &'static [u16; 19]> =
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_19.rs")));
-}
+seq!(N in 2..=9 {
+    lazy_static! {
+        #(pub(crate) static ref PHRASE_TABLE_~N: HashMap<&'static str, &'static [u16; N]> =
+            HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_", stringify!(N), ".rs")));)*
+    }
+});

--- a/src/data.rs
+++ b/src/data.rs
@@ -2,6 +2,7 @@
 
 use crate::{CharBlock, PinyinData};
 use std::collections::HashMap;
+use lazy_static::lazy_static;
 
 pub(crate) static PINYIN_DATA: &[PinyinData] =
     include!(concat!(env!("OUT_DIR"), "/pinyin_data.rs"));
@@ -12,5 +13,8 @@ pub(crate) static HETERONYM_TABLE: &[&[u16]] =
 
 pub(crate) static CHAR_BLOCKS: &[CharBlock] = include!(concat!(env!("OUT_DIR"), "/char_blocks.rs"));
 
-pub(crate) static PHRASE_TABLE: &[(&'static str, &[&[usize]])] =
-    include!(concat!(env!("OUT_DIR"), "/phrase_table.rs"));
+lazy_static! {
+    pub(crate) static ref PHRASE_TABLE: HashMap<&'static str, &'static [u16; 19]> = {
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table.rs")))
+    };
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::unreadable_literal)]
 
 use crate::{CharBlock, PinyinData};
-use std::collections::HashMap;
 use lazy_static::lazy_static;
+use std::collections::HashMap;
 
 pub(crate) static PINYIN_DATA: &[PinyinData] =
     include!(concat!(env!("OUT_DIR"), "/pinyin_data.rs"));
@@ -13,8 +13,44 @@ pub(crate) static HETERONYM_TABLE: &[&[u16]] =
 
 pub(crate) static CHAR_BLOCKS: &[CharBlock] = include!(concat!(env!("OUT_DIR"), "/char_blocks.rs"));
 
+pub(crate) static PHRASE_TABLE_HETERONYMS: &[(&'static str, &[&[u16]])] =
+    include!(concat!(env!("OUT_DIR"), "/phrase_table_heteronyms.rs"));
+
 lazy_static! {
-    pub(crate) static ref PHRASE_TABLE: HashMap<&'static str, &'static [u16; 19]> = {
-        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table.rs")))
-    };
+    pub(crate) static ref PHRASE_TABLE_2: HashMap<&'static str, &'static [u16; 2]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_2.rs")));
+    pub(crate) static ref PHRASE_TABLE_3: HashMap<&'static str, &'static [u16; 3]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_3.rs")));
+    pub(crate) static ref PHRASE_TABLE_4: HashMap<&'static str, &'static [u16; 4]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_4.rs")));
+    pub(crate) static ref PHRASE_TABLE_5: HashMap<&'static str, &'static [u16; 5]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_5.rs")));
+    pub(crate) static ref PHRASE_TABLE_6: HashMap<&'static str, &'static [u16; 6]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_6.rs")));
+    pub(crate) static ref PHRASE_TABLE_7: HashMap<&'static str, &'static [u16; 7]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_7.rs")));
+    pub(crate) static ref PHRASE_TABLE_8: HashMap<&'static str, &'static [u16; 8]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_8.rs")));
+    pub(crate) static ref PHRASE_TABLE_9: HashMap<&'static str, &'static [u16; 9]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_9.rs")));
+    pub(crate) static ref PHRASE_TABLE_10: HashMap<&'static str, &'static [u16; 10]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_10.rs")));
+    pub(crate) static ref PHRASE_TABLE_11: HashMap<&'static str, &'static [u16; 11]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_11.rs")));
+    pub(crate) static ref PHRASE_TABLE_12: HashMap<&'static str, &'static [u16; 12]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_12.rs")));
+    pub(crate) static ref PHRASE_TABLE_13: HashMap<&'static str, &'static [u16; 13]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_13.rs")));
+    pub(crate) static ref PHRASE_TABLE_14: HashMap<&'static str, &'static [u16; 14]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_14.rs")));
+    pub(crate) static ref PHRASE_TABLE_15: HashMap<&'static str, &'static [u16; 15]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_15.rs")));
+    pub(crate) static ref PHRASE_TABLE_16: HashMap<&'static str, &'static [u16; 16]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_16.rs")));
+    pub(crate) static ref PHRASE_TABLE_17: HashMap<&'static str, &'static [u16; 17]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_17.rs")));
+    pub(crate) static ref PHRASE_TABLE_18: HashMap<&'static str, &'static [u16; 18]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_18.rs")));
+    pub(crate) static ref PHRASE_TABLE_19: HashMap<&'static str, &'static [u16; 19]> =
+        HashMap::from(include!(concat!(env!("OUT_DIR"), "/phrase_table_19.rs")));
 }

--- a/src/pinyin.rs
+++ b/src/pinyin.rs
@@ -150,6 +150,7 @@ impl<'a> Iterator for PinyinStrIter<'a> {
     }
 }
 
+/// *辅助迭代器*，用于获取词组串的拼音信息
 pub struct PinyinPhraseIter<'a>(Iter<'a, &'a str>);
 
 impl<'a> Iterator for PinyinPhraseIter<'a> {
@@ -185,6 +186,21 @@ impl<'a> Iterator for PinyinPhraseIter<'a> {
     }
 }
 
+/// 分词后给每一个词语注音，如果一个词语中含有不支持的字符，词语的注音为None，
+/// 不然就生成一个Some(vec![..])，vec里面是词语中每个字的注音。
+/// ```
+/// # #[cfg(feature = "plain")] {
+/// use pinyin::{ToPinyin, Pinyin};
+/// let mut iter = ["薄荷", "是", "便宜货"].iter().to_pinyin();
+/// let mut next_plain = || iter.next().map(|ps|
+///     ps.map(|ps| ps.iter().map(|p|
+///         Pinyin::plain(*p)).collect::<Vec<_>>()));
+/// assert_eq!(next_plain(), Some(Some(vec!["bo", "he"])));
+/// assert_eq!(next_plain(), Some(Some(vec!["shi"])));
+/// assert_eq!(next_plain(), Some(Some(vec!["pian", "yi", "huo"])));
+/// assert_eq!(next_plain(), None);
+/// # }
+/// ```
 impl<'a> ToPinyin for Iter<'a, &'a str> {
     type Output = PinyinPhraseIter<'a>;
 


### PR DESCRIPTION
https://github.com/mozillazg/rust-pinyin/issues/56

加入了一个PinyinPhraseIter，用户提供一个词语串（已分词），拿到每个词语相应的拼音。如果一个词语中含有不支持的字符，整个词语的注音为None，不然就生成一个Some(vec![..])，vec里面是词语中每个字的注音。
```rust
# #[cfg(feature = "plain")] {
use pinyin::{ToPinyin, Pinyin};
let mut iter = ["薄荷", "是", "便宜货"].iter().to_pinyin();
let mut next_plain = || iter.next().map(|ps|
    ps.map(|ps| ps.iter().map(|p|
        Pinyin::plain(*p)).collect::<Vec<_>>()));
assert_eq!(next_plain(), Some(Some(vec!["bo", "he"])));
assert_eq!(next_plain(), Some(Some(vec!["shi"])));
assert_eq!(next_plain(), Some(Some(vec!["pian", "yi", "huo"])));
assert_eq!(next_plain(), None);
```
我觉得这个interface能用，但是比较别扭，欢迎提出更好的解决办法。