### PR TITLE
feat: impl Clone for Iterators

### DIFF
--- a/src/pinyin.rs
+++ b/src/pinyin.rs
@@ -1,5 +1,5 @@
 use crate::data::PINYIN_DATA;
-use crate::{get_block_and_index, PinyinData};
+use crate::{PinyinData, get_block_and_index};
 use std::str::Chars;
 
 /// 单个字符的拼音信息
@@ -134,6 +134,7 @@ impl<'a> ToPinyin for &'a str {
 }
 
 /// *辅助迭代器*，用于获取字符串的拼音信息
+#[derive(Debug, Clone)]
 pub struct PinyinStrIter<'a>(Chars<'a>);
 
 impl<'a> Iterator for PinyinStrIter<'a> {

--- a/src/pinyin_multi.rs
+++ b/src/pinyin_multi.rs
@@ -1,5 +1,5 @@
 use crate::data::{HETERONYM_TABLE, PINYIN_DATA};
-use crate::{get_block_and_index, Pinyin, PinyinData};
+use crate::{Pinyin, PinyinData, get_block_and_index};
 use std::str::Chars;
 
 /// 单个字符的多音字信息
@@ -46,6 +46,7 @@ impl IntoIterator for PinyinMulti {
 }
 
 /// *辅助迭代器*，用于迭代一个字的多个拼音
+#[derive(Clone)]
 pub struct PinyinMultiIter {
     inner: PinyinMulti,
     index: usize,


### PR DESCRIPTION
我常将`rust-pinyin`和`itertools`组合使用，尤其是笛卡尔积的迭代适配器方法[multi_cartesian_product](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.multi_cartesian_product)和[cartesian_product](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.cartesian_product)，在处理拼音方面非常有用。但它们都要求传入的迭代器具备`Clone`能力，而`rust-pinyin`的迭代器天生具备此能力，只是没有实现，导致要自己做workround。

如果此PR可以合并，麻烦即刻发一个新版本，万分感谢。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pinyin iterators can now be cloned and debug-formatted, making it easier to inspect, reuse, and log iterator state during troubleshooting.
  * These changes are cosmetic/diagnostic only—iteration behavior and error handling remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->